### PR TITLE
Refactor mosaic trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ float-cmp = "0.9.0"
 image = "0.24.2"
 palette = "0.6.0"
 voronoice = "0.2.0"
+
+[features]
+mosaic_with_preset_coloring = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub mod mosaic_shape;
 
 mod mosaic;
 pub use self::mosaic::Mosaic;
+#[cfg(feature = "mosaic_with_preset_coloring")]
+pub use self::mosaic::MosaicWithPresetColoring;
 
 mod mosaic_builder;
 pub use self::mosaic_builder::MosaicBuilder;

--- a/src/mosaic.rs
+++ b/src/mosaic.rs
@@ -4,6 +4,13 @@ use palette::{Gradient, IntoColor, LinSrgb, Mix, Shade};
 use super::{coloring_method::*, vector::Vector};
 
 pub trait Mosaic {
+    fn draw<Color, Method>(&self, coloring_method: Method) -> RgbImage
+    where
+        Color: IntoColor<LinSrgb<f64>> + Mix<Scalar = f64> + Shade<Scalar = f64> + Clone,
+        Method: ColoringMethod<Color>;
+}
+
+pub trait MosaicWithPresetColoring: Mosaic {
     fn draw_single_colored<Color>(&self, color: Color) -> RgbImage
     where
         Color: IntoColor<LinSrgb<f64>> + Mix<Scalar = f64> + Shade<Scalar = f64> + Clone,
@@ -190,8 +197,4 @@ pub trait Mosaic {
     {
         self.draw(ConicGradient::new_step(gradient, center, angle))
     }
-    fn draw<Color, Method>(&self, coloring_method: Method) -> RgbImage
-    where
-        Color: IntoColor<LinSrgb<f64>> + Mix<Scalar = f64> + Shade<Scalar = f64> + Clone,
-        Method: ColoringMethod<Color>;
 }

--- a/src/mosaic.rs
+++ b/src/mosaic.rs
@@ -1,20 +1,22 @@
 use image::RgbImage;
 use palette::{IntoColor, LinSrgb, Mix, Shade};
 
-use super::coloring_method::*;
+use super::{coloring_method::*, mosaic_shape::MosaicShape, vector::Vector};
 
 pub trait Mosaic {
     fn draw<Color, Method>(&self, coloring_method: Method) -> RgbImage
     where
         Color: IntoColor<LinSrgb<f64>> + Mix<Scalar = f64> + Shade<Scalar = f64> + Clone,
         Method: ColoringMethod<Color>;
+    fn image_size(&self) -> (u32, u32);
+    fn center(&self) -> Vector;
+    fn rotation_angle(&self) -> f64;
+    fn scale(&self) -> f64;
+    fn shape(&self) -> Box<dyn MosaicShape>;
 }
 
 #[cfg(feature = "mosaic_with_preset_coloring")]
 use palette::Gradient;
-
-#[cfg(feature = "mosaic_with_preset_coloring")]
-use super::vector::Vector;
 
 #[cfg(feature = "mosaic_with_preset_coloring")]
 pub trait MosaicWithPresetColoring: Mosaic {

--- a/src/mosaic.rs
+++ b/src/mosaic.rs
@@ -1,7 +1,7 @@
 use image::RgbImage;
-use palette::{Gradient, IntoColor, LinSrgb, Mix, Shade};
+use palette::{IntoColor, LinSrgb, Mix, Shade};
 
-use super::{coloring_method::*, vector::Vector};
+use super::coloring_method::*;
 
 pub trait Mosaic {
     fn draw<Color, Method>(&self, coloring_method: Method) -> RgbImage
@@ -10,6 +10,13 @@ pub trait Mosaic {
         Method: ColoringMethod<Color>;
 }
 
+#[cfg(feature = "mosaic_with_preset_coloring")]
+use palette::Gradient;
+
+#[cfg(feature = "mosaic_with_preset_coloring")]
+use super::vector::Vector;
+
+#[cfg(feature = "mosaic_with_preset_coloring")]
 pub trait MosaicWithPresetColoring: Mosaic {
     fn draw_single_colored<Color>(&self, color: Color) -> RgbImage
     where

--- a/src/mosaic_builder.rs
+++ b/src/mosaic_builder.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use voronoice::{BoundingBox, Point, VoronoiBuilder};
 
 use super::{
+    mosaic::Mosaic,
     mosaic_shape::{MosaicShape, PolygonalStar, RegularPolygon},
     starry_mosaic::StarryMosaic,
     vector::Vector,
@@ -99,6 +100,21 @@ impl Default for MosaicBuilder {
             center_point: Vector::new(200.0, 200.0),
             rotation_angle: 0.0,
             scale: 0.75,
+        }
+    }
+}
+
+impl<MosaicImage> From<&MosaicImage> for MosaicBuilder
+where
+    MosaicImage: Mosaic,
+{
+    fn from(mosaic: &MosaicImage) -> Self {
+        Self {
+            shape: mosaic.shape(),
+            image_size: mosaic.image_size(),
+            center_point: mosaic.center(),
+            rotation_angle: mosaic.rotation_angle(),
+            scale: mosaic.scale(),
         }
     }
 }

--- a/src/mosaic_builder.rs
+++ b/src/mosaic_builder.rs
@@ -64,7 +64,14 @@ impl MosaicBuilder {
             .set_sites(points)
             .build();
         match voronoi {
-            Some(voronoi) => Some(StarryMosaic::new(voronoi, self.image_size)),
+            Some(voronoi) => Some(StarryMosaic::new(
+                voronoi,
+                self.image_size,
+                self.center_point,
+                self.rotation_angle,
+                self.scale,
+                self.shape,
+            )),
             None => None,
         }
     }

--- a/src/mosaic_shape/mod.rs
+++ b/src/mosaic_shape/mod.rs
@@ -1,6 +1,8 @@
+use std::fmt::Debug;
+
 use super::{segment::Segment, vector::Vector};
 
-pub trait MosaicShape: MosaicShapeBase {
+pub trait MosaicShape: Debug + MosaicShapeBase {
     fn set_up_points(
         &self,
         image_size: (u32, u32),

--- a/src/starry_mosaic.rs
+++ b/src/starry_mosaic.rs
@@ -2,19 +2,36 @@ use image::{Rgb, RgbImage};
 use palette::{IntoColor, LinSrgb, Mix, Pixel, Shade};
 use voronoice::Voronoi;
 
-use super::{coloring_method::ColoringMethod, mosaic::Mosaic, vector::Vector};
+use super::{
+    coloring_method::ColoringMethod, mosaic::Mosaic, mosaic_shape::MosaicShape, vector::Vector,
+};
 
 #[derive(Clone, Debug)]
 pub struct StarryMosaic {
     voronoi: Voronoi,
     image_size: (u32, u32),
+    center: Vector,
+    rotation_angle: f64,
+    scale: f64,
+    shape: Box<dyn MosaicShape>,
 }
 
 impl StarryMosaic {
-    pub(crate) fn new(voronoi: Voronoi, image_size: (u32, u32)) -> Self {
+    pub(crate) fn new(
+        voronoi: Voronoi,
+        image_size: (u32, u32),
+        center: Vector,
+        rotation_angle: f64,
+        scale: f64,
+        shape: Box<dyn MosaicShape>,
+    ) -> Self {
         Self {
             voronoi,
             image_size,
+            center,
+            rotation_angle,
+            scale,
+            shape,
         }
     }
     fn calculate_maximum_cell_distances(&self) -> Vec<f64> {
@@ -66,5 +83,20 @@ impl Mosaic for StarryMosaic {
             *pixel = Rgb(color.into_format().into_raw())
         }
         mosaic_image
+    }
+    fn image_size(&self) -> (u32, u32) {
+        self.image_size
+    }
+    fn center(&self) -> Vector {
+        self.center.clone()
+    }
+    fn rotation_angle(&self) -> f64 {
+        self.rotation_angle
+    }
+    fn scale(&self) -> f64 {
+        self.scale
+    }
+    fn shape(&self) -> Box<dyn MosaicShape> {
+        self.shape.clone()
     }
 }


### PR DESCRIPTION
With this pull request Mosaic trait is extended; its extra funtional is split into separate trait.
These changes allow to add conversion between instances of implementers of Mosaic trait and MosaicBuilder struct.