### PR TITLE
Refactor Vector type and implement Copy trait for it

### DIFF
--- a/src/coloring_method/conic_gradient.rs
+++ b/src/coloring_method/conic_gradient.rs
@@ -57,7 +57,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 100.0);
     /// assert_eq!(
-    ///     conic_semi_step_gradient.interpolate(&Vector::new(100.0, 0.0), &key_point),
+    ///     conic_semi_step_gradient.interpolate(Vector::new(100.0, 0.0), key_point),
     ///     LinSrgb::new(1.0f64, 0.5, 0.0),
     /// );
     /// ```
@@ -73,7 +73,7 @@ where
         Self {
             gradient: gradient.into(),
             center,
-            angle: angle % (2.0 * consts::PI),
+            angle: angle % consts::TAU,
             smoothness: smoothness.clamp(0.0, 1.0),
         }
     }
@@ -117,7 +117,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 100.0);
     /// assert_eq!(
-    ///     conic_smooth_gradient.interpolate(&Vector::new(100.0, 0.0), &key_point),
+    ///     conic_smooth_gradient.interpolate(Vector::new(100.0, 0.0), key_point),
     ///     LinSrgb::new(1.0f64, 0.0, 0.0),
     /// );
     /// ```
@@ -168,7 +168,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 100.0);
     /// assert_eq!(
-    ///     conic_step_gradient.interpolate(&Vector::new(100.0, 0.0), &key_point),
+    ///     conic_step_gradient.interpolate(Vector::new(100.0, 0.0), key_point),
     ///     LinSrgb::new(1.0f64, 1.0, 0.0),
     /// );
     /// ```
@@ -182,7 +182,7 @@ where
 
     /// Center point around which conic gradient is drawn.
     pub fn center(&self) -> Vector {
-        self.center.clone()
+        self.center
     }
 
     /// Sets center point around which conic gradient is drawn.
@@ -197,7 +197,7 @@ where
 
     /// Sets angle at which to begin conic gradient, in radians.
     pub fn set_angle(&mut self, angle: f64) {
-        self.angle = angle % (2.0 * consts::PI);
+        self.angle = angle % consts::TAU;
     }
 
     /// Smoothness of conic gradient ranging from 0.0 to 1.0.
@@ -252,12 +252,12 @@ impl<Color> ColoringMethod<Color> for ConicGradient<Color>
 where
     Color: Mix<Scalar = f64> + Clone,
 {
-    fn interpolate(&self, point: &Vector, key_point: &Vector) -> Color {
+    fn interpolate(&self, point: Vector, key_point: Vector) -> Color {
         let smoothed_point = key_point.interpolate(point, self.smoothness);
-        let point_vector = &smoothed_point - &self.center;
+        let point_vector = smoothed_point - self.center;
         let angle = point_vector.y.atan2(point_vector.x) - self.angle;
-        let clamped_angle = (angle + 2.0 * consts::PI) % (2.0 * consts::PI);
-        self.gradient.get(clamped_angle / (2.0 * consts::PI))
+        let clamped_angle = (angle + consts::TAU) % consts::TAU;
+        self.gradient.get(clamped_angle / consts::TAU)
     }
 }
 
@@ -275,28 +275,28 @@ mod tests {
         );
         let key_point = Vector::new(100.0, 150.0);
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(150.0, 150.0), &key_point),
+            conic_gradient.interpolate(Vector::new(150.0, 150.0), key_point),
             gradient.get(0.0)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(100.0, 150.0), &key_point),
+            conic_gradient.interpolate(Vector::new(100.0, 150.0), key_point),
             gradient.get(0.125)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(50.0, 150.0), &key_point),
+            conic_gradient.interpolate(Vector::new(50.0, 150.0), key_point),
             gradient.get(0.25)
         );
         let key_point = Vector::new(100.0, 50.0);
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(50.0, 50.0), &key_point),
+            conic_gradient.interpolate(Vector::new(50.0, 50.0), key_point),
             gradient.get(0.5)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(100.0, 50.0), &key_point),
+            conic_gradient.interpolate(Vector::new(100.0, 50.0), key_point),
             gradient.get(0.625)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(150.0, 50.0), &key_point),
+            conic_gradient.interpolate(Vector::new(150.0, 50.0), key_point),
             gradient.get(0.75)
         );
     }
@@ -310,28 +310,28 @@ mod tests {
         );
         let key_point = Vector::new(150.0, 150.0);
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(150.0, 150.0), &key_point),
+            conic_gradient.interpolate(Vector::new(150.0, 150.0), key_point),
             gradient.get(0.25)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(100.0, 150.0), &key_point),
+            conic_gradient.interpolate(Vector::new(100.0, 150.0), key_point),
             gradient.get(0.25)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(50.0, 150.0), &key_point),
+            conic_gradient.interpolate(Vector::new(50.0, 150.0), key_point),
             gradient.get(0.25)
         );
         let key_point = Vector::new(50.0, 50.0);
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(50.0, 50.0), &key_point),
+            conic_gradient.interpolate(Vector::new(50.0, 50.0), key_point),
             gradient.get(0.75)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(100.0, 50.0), &key_point),
+            conic_gradient.interpolate(Vector::new(100.0, 50.0), key_point),
             gradient.get(0.75)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(150.0, 50.0), &key_point),
+            conic_gradient.interpolate(Vector::new(150.0, 50.0), key_point),
             gradient.get(0.75)
         );
     }
@@ -346,20 +346,20 @@ mod tests {
         );
         let key_point = Vector::new(150.0, 100.0);
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(100.0, 150.0), &key_point),
+            conic_gradient.interpolate(Vector::new(100.0, 150.0), key_point),
             gradient.get(0.0)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(100.0, 50.0), &key_point),
+            conic_gradient.interpolate(Vector::new(100.0, 50.0), key_point),
             gradient.get(0.75)
         );
         let key_point = Vector::new(50.0, 100.0);
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(100.0, 150.0), &key_point),
+            conic_gradient.interpolate(Vector::new(100.0, 150.0), key_point),
             gradient.get(0.25)
         );
         assert_eq!(
-            conic_gradient.interpolate(&Vector::new(100.0, 50.0), &key_point),
+            conic_gradient.interpolate(Vector::new(100.0, 50.0), key_point),
             gradient.get(0.5)
         );
     }
@@ -369,7 +369,7 @@ mod tests {
         let conic_gradient =
             ConicGradient::new_smooth(gradient.clone(), Vector::new(100.0, 100.0), 0.0);
         assert_eq!(
-            conic_gradient.interpolate(&conic_gradient.center(), &conic_gradient.center()),
+            conic_gradient.interpolate(conic_gradient.center(), conic_gradient.center()),
             gradient.get(0.0)
         );
     }

--- a/src/coloring_method/mod.rs
+++ b/src/coloring_method/mod.rs
@@ -35,7 +35,7 @@ use super::vector::Vector;
 /// where
 ///     Color: Mix<Scalar = f64> + Clone,
 /// {
-///     fn interpolate(&self, point: &Vector, key_point: &Vector) -> Color {
+///     fn interpolate(&self, point: Vector, key_point: Vector) -> Color {
 ///         if (point.x < key_point.x) == (point.y < key_point.y) {
 ///             self.primary.clone()
 ///         } else {
@@ -51,19 +51,19 @@ use super::vector::Vector;
 ///     };
 ///     let key_point = Vector::new(100.0, 100.0);
 ///     assert_eq!(
-///         pattern.interpolate(&Vector::new(50.0, 50.0), &key_point),
+///         pattern.interpolate(Vector::new(50.0, 50.0), key_point),
 ///         pattern.primary,
 ///     );
 ///     assert_eq!(
-///         pattern.interpolate(&Vector::new(50.0, 150.0), &key_point),
+///         pattern.interpolate(Vector::new(50.0, 150.0), key_point),
 ///         pattern.secondary,
 ///     );
 ///     assert_eq!(
-///         pattern.interpolate(&Vector::new(150.0, 50.0), &key_point),
+///         pattern.interpolate(Vector::new(150.0, 50.0), key_point),
 ///         pattern.secondary,
 ///     );
 ///     assert_eq!(
-///         pattern.interpolate(&Vector::new(150.0, 150.0), &key_point),
+///         pattern.interpolate(Vector::new(150.0, 150.0), key_point),
 ///         pattern.primary,
 ///     );
 /// }
@@ -86,7 +86,7 @@ where
     ///
     /// * [`ColoringMethod`].
     ///
-    fn interpolate(&self, point: &Vector, key_point: &Vector) -> Color;
+    fn interpolate(&self, point: Vector, key_point: Vector) -> Color;
 }
 
 impl<Color> ColoringMethod<Color> for Color
@@ -94,7 +94,7 @@ where
     Color: Mix<Scalar = f64> + Clone,
 {
     #[inline(always)]
-    fn interpolate(&self, _point: &Vector, _key_point: &Vector) -> Color {
+    fn interpolate(&self, _point: Vector, _key_point: Vector) -> Color {
         self.clone()
     }
 }

--- a/src/coloring_method/radial_gradient.rs
+++ b/src/coloring_method/radial_gradient.rs
@@ -62,7 +62,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 200.0);
     /// assert_eq!(
-    ///     radial_semi_step_gradient.interpolate(&Vector::new(200.0, 300.0), &key_point),
+    ///     radial_semi_step_gradient.interpolate(Vector::new(200.0, 300.0), key_point),
     ///     Lch::new(82.0f64, 108.0, 112.0),
     /// );
     /// ```
@@ -77,7 +77,7 @@ where
     where
         ColorGradient: Into<Gradient<Color>>,
     {
-        let direction = &outer_center - &inner_center;
+        let direction = outer_center - inner_center;
         let direction_squared_length = direction.squared_length();
         let mut radial_gradient = Self {
             gradient: gradient.into(),
@@ -135,7 +135,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 200.0);
     /// assert_eq!(
-    ///     radial_smooth_gradient.interpolate(&Vector::new(200.0, 300.0), &key_point),
+    ///     radial_smooth_gradient.interpolate(Vector::new(200.0, 300.0), key_point),
     ///     Lch::new(78.0f64, 102.0, 98.0),
     /// );
     /// ```
@@ -203,7 +203,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 200.0);
     /// assert_eq!(
-    ///     radial_step_gradient.interpolate(&Vector::new(200.0, 300.0), &key_point),
+    ///     radial_step_gradient.interpolate(Vector::new(200.0, 300.0), key_point),
     ///     Lch::new(66.0f64, 104.0, 76.0),
     /// );
     /// ```
@@ -269,7 +269,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 200.0);
     /// assert_eq!(
-    ///     radial_simple_semi_step_gradient.interpolate(&Vector::new(200.0, 300.0), &key_point),
+    ///     radial_simple_semi_step_gradient.interpolate(Vector::new(200.0, 300.0), key_point),
     ///     Lch::new(70.0f64, 105.0, 85.0),
     /// );
     /// ```
@@ -283,7 +283,7 @@ where
     where
         ColorGradient: Into<Gradient<Color>>,
     {
-        Self::new(gradient, center.clone(), 0.0, center, radius, smoothness)
+        Self::new(gradient, center, 0.0, center, radius, smoothness)
     }
 
     /// Creates radial simple smooth gradient using size and position of circle that bounds it.
@@ -327,7 +327,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 200.0);
     /// assert_eq!(
-    ///     radial_simple_smooth_gradient.interpolate(&Vector::new(200.0, 300.0), &key_point),
+    ///     radial_simple_smooth_gradient.interpolate(Vector::new(200.0, 300.0), key_point),
     ///     Lch::new(90.0f64, 110.0, 130.0),
     /// );
     /// ```
@@ -384,7 +384,7 @@ where
     ///
     /// let key_point = Vector::new(200.0, 200.0);
     /// assert_eq!(
-    ///     radial_simple_step_gradient.interpolate(&Vector::new(200.0, 300.0), &key_point),
+    ///     radial_simple_step_gradient.interpolate(Vector::new(200.0, 300.0), key_point),
     ///     Lch::new(50.0f64, 100.0, 40.0),
     /// );
     /// ```
@@ -402,7 +402,7 @@ where
 
     /// Center of inner circle of radial gradient.
     pub fn inner_center(&self) -> Vector {
-        self.inner_center.clone()
+        self.inner_center
     }
 
     /// Sets center of inner circle of radial gradient.
@@ -414,7 +414,7 @@ where
     ///
     /// * `inner_center`: center of inner circle.
     pub fn set_inner_center(&mut self, inner_center: Vector) {
-        let outer_center = &self.inner_center + &self.direction;
+        let outer_center = self.inner_center + self.direction;
         self.inner_center = inner_center;
         self.set_outer_center(outer_center);
     }
@@ -440,7 +440,7 @@ where
 
     /// Center of outer circle that bounds radial gradient.
     pub fn outer_center(&self) -> Vector {
-        &self.inner_center + &self.direction
+        self.inner_center + self.direction
     }
 
     /// Sets center of outer circle that bounds radial gradient.
@@ -452,7 +452,7 @@ where
     ///
     /// * `outer_center`: center of outer circle.
     pub fn set_outer_center(&mut self, outer_center: Vector) {
-        self.direction = &outer_center - &self.inner_center;
+        self.direction = outer_center - self.inner_center;
         self.direction_squared_length = self.direction.squared_length();
         self.fit_inner_circle_into_outer();
     }
@@ -538,11 +538,11 @@ impl<Color> ColoringMethod<Color> for RadialGradient<Color>
 where
     Color: Mix<Scalar = f64> + Clone,
 {
-    fn interpolate(&self, point: &Vector, key_point: &Vector) -> Color {
+    fn interpolate(&self, point: Vector, key_point: Vector) -> Color {
         let smoothed_point = key_point.interpolate(point, self.smoothness);
-        let point_vector = &smoothed_point - &self.inner_center;
+        let point_vector = smoothed_point - self.inner_center;
         let alpha = self.direction_squared_length - self.radius_difference.powi(2);
-        let beta = point_vector.dot(&self.direction) + self.inner_radius * self.radius_difference;
+        let beta = point_vector.dot(self.direction) + self.inner_radius * self.radius_difference;
         let gamma = point_vector.squared_length() - self.inner_radius.powi(2);
         let discriminant = beta * beta - alpha * gamma;
         let interpolation_factor = (beta - discriminant.sqrt()) / alpha;
@@ -653,7 +653,7 @@ mod tests {
             let index = index as f64;
             let point = Vector::new(250.0, 200.0 + index * 50.0);
             assert_eq!(
-                radial_gradient.interpolate(&point, &key_point),
+                radial_gradient.interpolate(point, key_point),
                 gradient.get(index / 5.0)
             );
         }
@@ -662,7 +662,7 @@ mod tests {
             let index = index as f64;
             let point = Vector::new(250.0, 100.0 - index * 10.0);
             assert_eq!(
-                radial_gradient.interpolate(&point, &key_point),
+                radial_gradient.interpolate(point, key_point),
                 gradient.get(index / 5.0)
             );
         }
@@ -682,7 +682,7 @@ mod tests {
             let index = index as f64;
             let point = Vector::new(250.0, 200.0 + index * 50.0);
             assert_eq!(
-                radial_gradient.interpolate(&point, &key_point),
+                radial_gradient.interpolate(point, key_point),
                 gradient.get(0.5)
             );
         }
@@ -691,7 +691,7 @@ mod tests {
             let index = index as f64;
             let point = Vector::new(250.0, 100.0 - index * 10.0);
             assert_eq!(
-                radial_gradient.interpolate(&point, &key_point),
+                radial_gradient.interpolate(point, key_point),
                 gradient.get(0.5)
             );
         }
@@ -712,7 +712,7 @@ mod tests {
             let index = index as f64;
             let point = Vector::new(250.0, 200.0 + index * 50.0);
             assert_eq!(
-                radial_gradient.interpolate(&point, &key_point),
+                radial_gradient.interpolate(point, key_point),
                 gradient.get(0.25 + index / 10.0)
             );
         }
@@ -721,7 +721,7 @@ mod tests {
             let index = index as f64;
             let point = Vector::new(250.0, 100.0 - index * 10.0);
             assert_eq!(
-                radial_gradient.interpolate(&point, &key_point),
+                radial_gradient.interpolate(point, key_point),
                 gradient.get(0.25 + index / 10.0)
             );
         }
@@ -737,8 +737,7 @@ mod tests {
             200.0,
         );
         assert_eq!(
-            radial_gradient
-                .interpolate(&radial_gradient.inner_center, &radial_gradient.inner_center),
+            radial_gradient.interpolate(radial_gradient.inner_center, radial_gradient.inner_center),
             gradient.get(0.0)
         );
     }
@@ -754,22 +753,22 @@ mod tests {
         );
         let point = Vector::new(0.0, 250.0);
         assert_eq!(
-            radial_gradient.interpolate(&point, &radial_gradient.inner_center),
+            radial_gradient.interpolate(point, radial_gradient.inner_center),
             gradient.get(1.0)
         );
         let point = Vector::new(500.0, 250.0);
         assert_eq!(
-            radial_gradient.interpolate(&point, &radial_gradient.inner_center),
+            radial_gradient.interpolate(point, radial_gradient.inner_center),
             gradient.get(1.0)
         );
         let point = Vector::new(250.0, 0.0);
         assert_eq!(
-            radial_gradient.interpolate(&point, &radial_gradient.inner_center),
+            radial_gradient.interpolate(point, radial_gradient.inner_center),
             gradient.get(1.0)
         );
         let point = Vector::new(250.0, 500.0);
         assert_eq!(
-            radial_gradient.interpolate(&point, &radial_gradient.inner_center),
+            radial_gradient.interpolate(point, radial_gradient.inner_center),
             gradient.get(1.0)
         );
     }

--- a/src/mosaic.rs
+++ b/src/mosaic.rs
@@ -61,7 +61,7 @@ use super::{coloring_method::*, mosaic_shape::MosaicShape, vector::Vector};
 ///     }
 ///     fn draw_dot<Color, Method>(
 ///         &self,
-///         key_point: &Vector,
+///         key_point: Vector,
 ///         coloring_method: &Method,
 ///         mosaic_image: &mut RgbImage
 ///     )
@@ -82,10 +82,10 @@ use super::{coloring_method::*, mosaic_shape::MosaicShape, vector::Vector};
 ///                     || point.y >= image_height {
 ///                     continue;
 ///                 }
-///                 if (&point - key_point).length() > self.dot_radius as f64 {
+///                 if point.distance_to(key_point) > self.dot_radius as f64 {
 ///                     continue;
 ///                 }
-///                 let color = coloring_method.interpolate(&point, key_point).into_color();
+///                 let color = coloring_method.interpolate(point, key_point).into_color();
 ///                 mosaic_image.put_pixel(
 ///                     point.x as u32,
 ///                     point.y as u32,
@@ -102,7 +102,7 @@ use super::{coloring_method::*, mosaic_shape::MosaicShape, vector::Vector};
 ///         Method: ColoringMethod<Color>,
 ///     {
 ///         let mut mosaic_image = RgbImage::new(self.image_size.0, self.image_size.1);
-///         for key_point in &self.key_points {
+///         for key_point in self.key_points {
 ///             self.draw_dot(key_point, &coloring_method, &mut mosaic_image);
 ///         }
 ///         mosaic_image
@@ -110,8 +110,8 @@ use super::{coloring_method::*, mosaic_shape::MosaicShape, vector::Vector};
 ///     fn image_size(&self) -> (u32, u32) {
 ///         self.image_size
 ///     }
-///     fn center(&self) -> &Vector {
-///         &self.center
+///     fn center(&self) -> Vector {
+///         self.center
 ///     }
 ///     fn rotation_angle(&self) -> f64 {
 ///         self.rotation_angle
@@ -133,7 +133,7 @@ use super::{coloring_method::*, mosaic_shape::MosaicShape, vector::Vector};
 ///         .build_from_key_points(DottedMosaic::new);
 ///
 ///     assert_eq!(dotted_mosaic.image_size(), (1024, 1024));
-///     assert_eq!(dotted_mosaic.center(), &Vector::new(512.0, 512.0));
+///     assert_eq!(dotted_mosaic.center(), Vector::new(512.0, 512.0));
 ///     assert_eq!(dotted_mosaic.rotation_angle(), 45.0f64.to_radians());
 ///     assert_eq!(dotted_mosaic.scale(), 0.75);
 ///
@@ -168,7 +168,7 @@ pub trait Mosaic {
     fn image_size(&self) -> (u32, u32);
 
     /// Position of center of [mosaic shape][`Mosaic::shape`] in mosaic.
-    fn center(&self) -> &Vector;
+    fn center(&self) -> Vector;
 
     /// Rotation angle (in radians) of [mosaic shape][`Mosaic::shape`] in this mosaic.
     fn rotation_angle(&self) -> f64;

--- a/src/mosaic.rs
+++ b/src/mosaic.rs
@@ -102,8 +102,8 @@ use super::{coloring_method::*, mosaic_shape::MosaicShape, vector::Vector};
 ///         Method: ColoringMethod<Color>,
 ///     {
 ///         let mut mosaic_image = RgbImage::new(self.image_size.0, self.image_size.1);
-///         for key_point in self.key_points {
-///             self.draw_dot(key_point, &coloring_method, &mut mosaic_image);
+///         for key_point in &self.key_points {
+///             self.draw_dot(*key_point, &coloring_method, &mut mosaic_image);
 ///         }
 ///         mosaic_image
 ///     }

--- a/src/mosaic_builder.rs
+++ b/src/mosaic_builder.rs
@@ -31,7 +31,7 @@ use super::{
 /// let starry_mosaic = starry_mosaic.unwrap();
 ///
 /// assert_eq!(starry_mosaic.image_size(), (1024, 1024));
-/// assert_eq!(starry_mosaic.center(), &Vector::new(512.0, 512.0));
+/// assert_eq!(starry_mosaic.center(), Vector::new(512.0, 512.0));
 /// assert_eq!(starry_mosaic.rotation_angle(), 22.5f64.to_radians());
 /// assert_eq!(starry_mosaic.scale(), 0.5);
 ///
@@ -276,7 +276,7 @@ impl MosaicBuilder {
         let points = self
             .construct_shape()
             .iter()
-            .map(|point| point.into())
+            .map(|point| (*point).into())
             .collect();
         let (image_width, image_height) = (self.image_size.0 as f64, self.image_size.1 as f64);
         let center = Point {
@@ -348,7 +348,7 @@ impl MosaicBuilder {
     fn construct_shape(&self) -> Vec<Vector> {
         let mut initial_points = self.shape.set_up_points(
             self.image_size,
-            self.center.clone(),
+            self.center,
             self.rotation_angle,
             self.scale,
         );
@@ -384,7 +384,7 @@ where
         Self {
             shape: mosaic.shape().clone(),
             image_size: mosaic.image_size(),
-            center: mosaic.center().clone(),
+            center: mosaic.center(),
             rotation_angle: mosaic.rotation_angle(),
             scale: mosaic.scale(),
         }

--- a/src/mosaic_shape/mod.rs
+++ b/src/mosaic_shape/mod.rs
@@ -68,21 +68,15 @@ use super::{segment::Segment, vector::Vector};
 ///         }
 ///         points
 ///             .iter()
-///             .map(|point| &point.rotate(rotation_angle) + &center)
+///             .map(|point| point.rotate(rotation_angle) + center)
 ///             .collect()
 ///     }
 ///     fn connect_points(&self, shape_points: &Vec<Vector>) -> Vec<Segment> {
 ///         let mut segments = vec![];
 ///         let points_count = shape_points.len();
 ///         for index in (0..points_count).step_by(4) {
-///             segments.push(Segment::new(
-///                 shape_points[index].clone(),
-///                 shape_points[index + 1].clone(),
-///             ));
-///             segments.push(Segment::new(
-///                 shape_points[index + 2].clone(),
-///                 shape_points[index + 3].clone(),
-///             ));
+///             segments.push(Segment::new(shape_points[index], shape_points[index + 1]));
+///             segments.push(Segment::new(shape_points[index + 2], shape_points[index + 3]));
 ///         }
 ///         segments
 ///     }

--- a/src/mosaic_shape/polygonal_star.rs
+++ b/src/mosaic_shape/polygonal_star.rs
@@ -64,12 +64,8 @@ impl MosaicShape for PolygonalStar {
         let inner_radius = radius
             * (consts::PI * (corners_count * 0.5 - 2.0) / corners_count).sin()
             / (consts::FRAC_PI_2 * (corners_count - 2.0) / corners_count).sin();
-        let mut points = helpers::set_up_polygon_points(
-            self.corners_count,
-            radius,
-            center.clone(),
-            rotation_angle,
-        );
+        let mut points =
+            helpers::set_up_polygon_points(self.corners_count, radius, center, rotation_angle);
         let mut inner_points = helpers::set_up_polygon_points(
             self.corners_count,
             inner_radius,
@@ -86,16 +82,16 @@ impl MosaicShape for PolygonalStar {
         for start_index in 0..points_count {
             let end_index = (start_index + 2) % points_count;
             segments.push(Segment::new(
-                shape_points[start_index].clone(),
-                shape_points[end_index].clone(),
+                shape_points[start_index],
+                shape_points[end_index],
             ));
         }
         for start_index in 0..points_count {
             for end_index in start_index + 2..start_index + points_count - 2 {
                 let end_index = points_count + end_index % points_count;
                 segments.push(Segment::new(
-                    shape_points[start_index].clone(),
-                    shape_points[end_index].clone(),
+                    shape_points[start_index],
+                    shape_points[end_index],
                 ));
             }
         }

--- a/src/mosaic_shape/regular_polygon.rs
+++ b/src/mosaic_shape/regular_polygon.rs
@@ -63,8 +63,8 @@ impl MosaicShape for RegularPolygon {
         for start_index in 0..points_count - 1 {
             for end_index in start_index + 1..points_count {
                 segments.push(Segment::new(
-                    shape_points[start_index].clone(),
-                    shape_points[end_index].clone(),
+                    shape_points[start_index],
+                    shape_points[end_index],
                 ));
             }
         }

--- a/src/mosaic_shape/tilted_grid.rs
+++ b/src/mosaic_shape/tilted_grid.rs
@@ -142,10 +142,10 @@ impl MosaicShape for TiltedGrid {
         points
             .iter()
             .map(|point| {
-                &point
+                point
                     .shear(self.tilt_factor.x, self.tilt_factor.y)
                     .rotate(rotation_angle)
-                    + &center
+                    + center
             })
             .collect()
     }
@@ -154,10 +154,7 @@ impl MosaicShape for TiltedGrid {
         let mut segments = vec![];
         let points_count = shape_points.len();
         for index in (4..points_count).step_by(2) {
-            segments.push(Segment::new(
-                shape_points[index].clone(),
-                shape_points[index + 1].clone(),
-            ));
+            segments.push(Segment::new(shape_points[index], shape_points[index + 1]));
         }
         segments
     }

--- a/src/polygonal_mosaic.rs
+++ b/src/polygonal_mosaic.rs
@@ -65,7 +65,7 @@ impl PolygonalMosaic {
             (&sites[triangulation.triangles[vertex_index * 3 + 1]]).into(),
             (&sites[triangulation.triangles[vertex_index * 3 + 2]]).into(),
         ];
-        let radius = vertex_position.distance_to(&corner_positions[0].into());
+        let radius = vertex_position.distance_to(corner_positions[0].into());
         let x_min = f64::min(corner_positions[0].x, corner_positions[1].x)
             .min(corner_positions[2].x)
             .round() as u32;
@@ -82,15 +82,15 @@ impl PolygonalMosaic {
             for y in y_min..=y_max {
                 let position = Vector::new(x as f64, y as f64);
                 let orientations = [
-                    robust::orient2d(corner_positions[0], corner_positions[1], (&position).into()),
-                    robust::orient2d(corner_positions[1], corner_positions[2], (&position).into()),
-                    robust::orient2d(corner_positions[2], corner_positions[0], (&position).into()),
+                    robust::orient2d(corner_positions[0], corner_positions[1], position.into()),
+                    robust::orient2d(corner_positions[1], corner_positions[2], position.into()),
+                    robust::orient2d(corner_positions[2], corner_positions[0], position.into()),
                 ];
                 if orientations[0] <= 0.0 && orientations[1] <= 0.0 && orientations[2] <= 0.0 {
-                    let distance = position.distance_to(&vertex_position);
+                    let distance = position.distance_to(vertex_position);
                     let lightness = (1.0 - distance / radius).powi(2);
                     let color = coloring_method
-                        .interpolate(&position, &vertex_position)
+                        .interpolate(position, vertex_position)
                         .lighten(lightness)
                         .into_color();
                     mosaic_image.put_pixel(x, y, Rgb(color.into_format().into_raw()));
@@ -118,8 +118,8 @@ impl Mosaic for PolygonalMosaic {
         self.image_size
     }
 
-    fn center(&self) -> &Vector {
-        &self.center
+    fn center(&self) -> Vector {
+        self.center
     }
 
     fn rotation_angle(&self) -> f64 {

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -14,8 +14,8 @@ use super::{utility, vector::Vector};
 /// let start_point = Vector::new(6.4, -2.3);
 /// let end_point = Vector::new(1.7, 7.8);
 ///
-/// let segment = Segment::new(start_point.clone(), end_point.clone());
-/// let inverse_segment = Segment::new(end_point.clone(), start_point.clone());
+/// let segment = Segment::new(start_point, end_point);
+/// let inverse_segment = Segment::new(end_point, start_point);
 ///
 /// assert_eq!(segment, inverse_segment);
 /// ```
@@ -49,7 +49,7 @@ impl Segment {
     /// assert_eq!(segment.squared_length(), 169.0);
     /// ```
     pub fn squared_length(&self) -> f64 {
-        self.start.squared_distance_to(&self.end)
+        self.start.squared_distance_to(self.end)
     }
 
     /// Calculates length of line segment.
@@ -64,7 +64,7 @@ impl Segment {
     /// assert_eq!(segment.length(), 13.0);
     /// ```
     pub fn length(&self) -> f64 {
-        self.start.distance_to(&self.end)
+        self.start.distance_to(self.end)
     }
 
     /// Computes point of intersection of this line segment with another one, if such point exists.
@@ -83,15 +83,15 @@ impl Segment {
     /// assert_eq!(point, Vector::new(0.0, 0.0));
     /// ```
     pub fn intersect(&self, segment: &Self) -> Option<Vector> {
-        let self_vector = &self.end - &self.start;
-        let segment_vector = &segment.end - &segment.start;
-        let denominator = self_vector.cross(&segment_vector);
+        let self_vector = self.end - self.start;
+        let segment_vector = segment.end - segment.start;
+        let denominator = self_vector.cross(segment_vector);
         if !utility::approx_eq(denominator, 0.0) {
-            let start_vector = &self.start - &segment.start;
-            let numerator = segment_vector.cross(&start_vector);
+            let start_vector = self.start - segment.start;
+            let numerator = segment_vector.cross(start_vector);
             let factor = numerator / denominator;
             if factor > 0.0 && factor < 1.0 {
-                return Some(self.start.interpolate(&self.end, factor));
+                return Some(self.start.interpolate(self.end, factor));
             }
         }
         None

--- a/src/starry_mosaic.rs
+++ b/src/starry_mosaic.rs
@@ -52,7 +52,7 @@ impl StarryMosaic {
             let site = cell.site();
             let site_position: Vector = cell.site_position().into();
             cell.iter_vertices().for_each(|vertex| {
-                let distance = site_position.distance_to(&vertex.into());
+                let distance = site_position.distance_to(vertex.into());
                 if distance > maximum_cell_distances[site] {
                     maximum_cell_distances[site] = distance;
                 }
@@ -61,7 +61,7 @@ impl StarryMosaic {
         maximum_cell_distances
     }
 
-    fn find_closest_site(&self, site: usize, vector: &Vector) -> usize {
+    fn find_closest_site(&self, site: usize, vector: Vector) -> usize {
         self.voronoi
             .cell(site)
             .iter_path(vector.into())
@@ -82,15 +82,15 @@ impl Mosaic for StarryMosaic {
         let mut current_site_position = Vector::default();
         for (x, y, pixel) in mosaic_image.enumerate_pixels_mut() {
             let position = Vector::new(x as f64, y as f64);
-            let site = self.find_closest_site(current_site, &position);
+            let site = self.find_closest_site(current_site, position);
             if site == 0 || current_site != site {
                 current_site = site;
                 current_site_position = (&self.voronoi.sites()[current_site]).into();
             }
-            let distance = position.distance_to(&current_site_position);
+            let distance = position.distance_to(current_site_position);
             let lightness = (1.0 - distance / maximum_cell_distances[current_site]).powi(2);
             let color = coloring_method
-                .interpolate(&position, &current_site_position)
+                .interpolate(position, current_site_position)
                 .lighten(lightness)
                 .into_color();
             *pixel = Rgb(color.into_format().into_raw());
@@ -102,8 +102,8 @@ impl Mosaic for StarryMosaic {
         self.image_size
     }
 
-    fn center(&self) -> &Vector {
-        &self.center
+    fn center(&self) -> Vector {
+        self.center
     }
 
     fn rotation_angle(&self) -> f64 {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -21,15 +21,15 @@ use super::utility;
 ///
 /// let first_vector = Vector::new(1.0, -4.0);
 /// let second_vector = Vector::new(3.0, 5.0);
-/// let sum = &first_vector + &second_vector;
+/// let sum = first_vector + second_vector;
 ///
 /// assert_eq!(sum, Vector::new(4.0, 1.0));
-/// assert_eq!(&sum - &first_vector, second_vector);
+/// assert_eq!(sum - first_vector, second_vector);
 ///
-/// let scaled_sum = 4.0 * &sum;
+/// let scaled_sum = 4.0 * sum;
 ///
 /// assert_eq!(scaled_sum, Vector::new(16.0, 4.0));
-/// assert_eq!(&scaled_sum / 4.0, sum);
+/// assert_eq!(scaled_sum / 4.0, sum);
 /// ```
 ///
 /// Comparison of vectors takes into account the error of floating point calculations.
@@ -42,7 +42,7 @@ use super::utility;
 ///
 /// assert_eq!(vector, similar_vector);
 /// ```
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Default)]
 pub struct Vector {
     /// X coordinate (abscissa) of vector.
     pub x: f64,
@@ -104,11 +104,11 @@ impl Vector {
     /// let start_point = Vector::new(-1.0, 7.0);
     /// let end_point = Vector::new(4.0, -5.0);
     ///
-    /// assert_eq!(start_point.squared_distance_to(&end_point), 169.0);
+    /// assert_eq!(start_point.squared_distance_to(end_point), 169.0);
     /// ```
     #[inline(always)]
-    pub fn squared_distance_to(&self, point: &Self) -> f64 {
-        (self - point).squared_length()
+    pub fn squared_distance_to(&self, point: Self) -> f64 {
+        (*self - point).squared_length()
     }
 
     /// Finds distance from this to another point.
@@ -127,11 +127,11 @@ impl Vector {
     /// let start_point = Vector::new(6.0, -7.0);
     /// let end_point = Vector::new(1.0, 5.0);
     ///
-    /// assert_eq!(start_point.distance_to(&end_point), 13.0);
+    /// assert_eq!(start_point.distance_to(end_point), 13.0);
     /// ```
     #[inline(always)]
-    pub fn distance_to(&self, point: &Self) -> f64 {
-        (self - point).length()
+    pub fn distance_to(&self, point: Self) -> f64 {
+        (*self - point).length()
     }
 
     /// Creates normalized vector (one with same direction and magnitude of 1).
@@ -146,7 +146,7 @@ impl Vector {
     /// assert_eq!(vector.get_normalized(), Vector::new(0.8, 0.6));
     /// ```
     pub fn get_normalized(&self) -> Self {
-        self / self.length()
+        *self / self.length()
     }
 
     /// Computes dot product of two vectors.
@@ -165,10 +165,10 @@ impl Vector {
     /// let first_vector = Vector::new(2.5, -3.0);
     /// let second_vector = Vector::new(-4.0, 7.0);
     ///
-    /// assert_eq!(first_vector.dot(&second_vector), -31.0);
-    /// assert_eq!(first_vector.dot(&second_vector), second_vector.dot(&first_vector));
+    /// assert_eq!(first_vector.dot(second_vector), -31.0);
+    /// assert_eq!(first_vector.dot(second_vector), second_vector.dot(first_vector));
     /// ```
-    pub fn dot(&self, vector: &Self) -> f64 {
+    pub fn dot(&self, vector: Self) -> f64 {
         self.x * vector.x + self.y * vector.y
     }
 
@@ -190,9 +190,9 @@ impl Vector {
     /// let source_vector = Vector::new(2.0, -4.5);
     /// let target_vector = Vector::new(-1.5, 3.0);
     ///
-    /// assert_eq!(source_vector.cross(&target_vector), 0.75);
+    /// assert_eq!(source_vector.cross(target_vector), 0.75);
     /// ```
-    pub fn cross(&self, vector: &Self) -> f64 {
+    pub fn cross(&self, vector: Self) -> f64 {
         self.y * vector.x - self.x * vector.y
     }
 
@@ -212,11 +212,11 @@ impl Vector {
     ///
     /// let start_point = Vector::new(-2.0, 3.0);
     /// let end_point = Vector::new(7.0, -1.0);
-    /// let interpolated_point = start_point.interpolate(&end_point, 0.4);
+    /// let interpolated_point = start_point.interpolate(end_point, 0.4);
     ///
     /// assert_eq!(interpolated_point, Vector::new(1.6, 1.4));
     /// ```
-    pub fn interpolate(&self, vector: &Self, factor: f64) -> Self {
+    pub fn interpolate(&self, vector: Self, factor: f64) -> Self {
         let factor = factor.clamp(0.0, 1.0);
         Self {
             x: self.x + (vector.x - self.x) * factor,
@@ -239,13 +239,13 @@ impl Vector {
     /// use starry_mosaic::Vector;
     ///
     /// let point = Vector::new(-5.0, 7.0);
-    /// let translated_point = point.translate(&Vector::new(2.0, -3.0));
+    /// let translated_point = point.translate(Vector::new(2.0, -3.0));
     ///
     /// assert_eq!(translated_point, Vector::new(-3.0, 4.0));
     /// ```
     #[inline(always)]
-    pub fn translate(&self, vector: &Self) -> Self {
-        self + vector
+    pub fn translate(&self, vector: Self) -> Self {
+        *self + vector
     }
 
     /// Rotates current point around origin (0.0, 0.0).
@@ -297,13 +297,13 @@ impl Vector {
     /// let pivot_point = Vector::new(-1.0, -1.0);
     ///
     /// assert_eq!(
-    ///     point.rotate_around_pivot(consts::FRAC_PI_4, &pivot_point),
+    ///     point.rotate_around_pivot(consts::FRAC_PI_4, pivot_point),
     ///     Vector::new(-1.0, 7.0)
     /// );
     /// ```
     #[inline(always)]
-    pub fn rotate_around_pivot(&self, angle: f64, pivot: &Self) -> Self {
-        &(self - pivot).rotate(angle) + pivot
+    pub fn rotate_around_pivot(&self, angle: f64, pivot: Self) -> Self {
+        (*self - pivot).rotate(angle) + pivot
     }
 
     /// Scales current vector by specified factors.
@@ -328,7 +328,7 @@ impl Vector {
     /// ```
     #[inline(always)]
     pub fn scale(&self, horizontal_scale: f64, vertical_scale: f64) -> Self {
-        self * (horizontal_scale, vertical_scale)
+        *self * (horizontal_scale, vertical_scale)
     }
 
     /// Shears current point by specified factors.
@@ -409,16 +409,16 @@ impl From<&Point> for Vector {
         }
     }
 }
-impl From<&Vector> for Coord<f64> {
-    fn from(vector: &Vector) -> Self {
+impl From<Vector> for Coord<f64> {
+    fn from(vector: Vector) -> Self {
         Self {
             x: vector.x,
             y: vector.y,
         }
     }
 }
-impl From<&Vector> for Point {
-    fn from(vector: &Vector) -> Self {
+impl From<Vector> for Point {
+    fn from(vector: Vector) -> Self {
         Self {
             x: vector.x,
             y: vector.y,
@@ -445,25 +445,25 @@ impl PartialOrd for Vector {
     }
 }
 
-impl Add<&Vector> for &Vector {
+impl Add for Vector {
     type Output = Vector;
-    fn add(self, vector: &Vector) -> Self::Output {
+    fn add(self, vector: Vector) -> Self::Output {
         Vector {
             x: self.x + vector.x,
             y: self.y + vector.y,
         }
     }
 }
-impl Sub<&Vector> for &Vector {
+impl Sub for Vector {
     type Output = Vector;
-    fn sub(self, vector: &Vector) -> Self::Output {
+    fn sub(self, vector: Vector) -> Self::Output {
         Vector {
             x: self.x - vector.x,
             y: self.y - vector.y,
         }
     }
 }
-impl Mul<f64> for &Vector {
+impl Mul<f64> for Vector {
     type Output = Vector;
     fn mul(self, scale: f64) -> Self::Output {
         Vector {
@@ -472,16 +472,16 @@ impl Mul<f64> for &Vector {
         }
     }
 }
-impl Mul<&Vector> for f64 {
+impl Mul<Vector> for f64 {
     type Output = Vector;
-    fn mul(self, vector: &Vector) -> Self::Output {
+    fn mul(self, vector: Vector) -> Self::Output {
         Vector {
             x: self * vector.x,
             y: self * vector.y,
         }
     }
 }
-impl Mul<(f64, f64)> for &Vector {
+impl Mul<(f64, f64)> for Vector {
     type Output = Vector;
     fn mul(self, scale: (f64, f64)) -> Self::Output {
         Vector {
@@ -490,16 +490,16 @@ impl Mul<(f64, f64)> for &Vector {
         }
     }
 }
-impl Mul<&Vector> for (f64, f64) {
+impl Mul<Vector> for (f64, f64) {
     type Output = Vector;
-    fn mul(self, vector: &Vector) -> Self::Output {
+    fn mul(self, vector: Vector) -> Self::Output {
         Vector {
             x: self.0 * vector.x,
             y: self.1 * vector.y,
         }
     }
 }
-impl Div<f64> for &Vector {
+impl Div<f64> for Vector {
     type Output = Vector;
     fn div(self, scale: f64) -> Self::Output {
         Vector {
@@ -508,7 +508,7 @@ impl Div<f64> for &Vector {
         }
     }
 }
-impl Div<(f64, f64)> for &Vector {
+impl Div<(f64, f64)> for Vector {
     type Output = Vector;
     fn div(self, scale: (f64, f64)) -> Self::Output {
         Vector {
@@ -518,7 +518,7 @@ impl Div<(f64, f64)> for &Vector {
     }
 }
 
-impl Neg for &Vector {
+impl Neg for Vector {
     type Output = Vector;
     fn neg(self) -> Self::Output {
         Vector {
@@ -528,14 +528,14 @@ impl Neg for &Vector {
     }
 }
 
-impl AddAssign<&Vector> for Vector {
-    fn add_assign(&mut self, vector: &Vector) {
+impl AddAssign for Vector {
+    fn add_assign(&mut self, vector: Vector) {
         self.x += vector.x;
         self.y += vector.y;
     }
 }
-impl SubAssign<&Vector> for Vector {
-    fn sub_assign(&mut self, vector: &Vector) {
+impl SubAssign for Vector {
+    fn sub_assign(&mut self, vector: Vector) {
         self.x -= vector.x;
         self.y -= vector.y;
     }
@@ -596,31 +596,31 @@ mod tests {
     fn dot() {
         let first = Vector::new(3.0, 5.0);
         let second = Vector::new(4.0, 2.0);
-        assert_eq!(first.dot(&second), 22.0);
+        assert_eq!(first.dot(second), 22.0);
     }
     #[test]
     fn dot_self_is_squared_length() {
         let vector = Vector::new(7.5, 4.0);
-        assert_eq!(vector.dot(&vector), vector.squared_length());
+        assert_eq!(vector.dot(vector), vector.squared_length());
     }
     #[test]
     fn cross() {
         let first = Vector::new(5.0, 4.0);
         let second = Vector::new(3.0, 2.0);
-        assert_eq!(first.cross(&second), 2.0);
+        assert_eq!(first.cross(second), 2.0);
     }
     #[test]
     fn interpolate() {
         let first = Vector::new(5.0, 6.0);
         let second = Vector::new(1.0, -2.0);
-        let interpolation = first.interpolate(&second, 0.25);
+        let interpolation = first.interpolate(second, 0.25);
         assert_eq!(interpolation.x, 4.0);
         assert_eq!(interpolation.y, 4.0);
     }
     #[test]
     fn translate() {
         let point = Vector::new(7.0, -2.0);
-        let translated_point = point.translate(&Vector::new(3.0, 3.0));
+        let translated_point = point.translate(Vector::new(3.0, 3.0));
         assert_eq!(translated_point, Vector::new(10.0, 1.0));
     }
     #[test]
@@ -641,15 +641,15 @@ mod tests {
         let vector = Vector::new(5.0, 2.0);
         let pivot = Vector::new(1.0, 2.0);
         assert_eq!(
-            vector.rotate_around_pivot(consts::FRAC_PI_2, &pivot),
+            vector.rotate_around_pivot(consts::FRAC_PI_2, pivot),
             Vector::new(1.0, 6.0)
         );
         assert_eq!(
-            vector.rotate_around_pivot(consts::FRAC_PI_3, &pivot),
+            vector.rotate_around_pivot(consts::FRAC_PI_3, pivot),
             Vector::new(3.0, 2.0 + 2.0 * 3.0f64.sqrt())
         );
         assert_eq!(
-            vector.rotate_around_pivot(consts::FRAC_PI_6, &pivot),
+            vector.rotate_around_pivot(consts::FRAC_PI_6, pivot),
             Vector::new(1.0 + 2.0 * 3.0f64.sqrt(), 4.0)
         );
     }
@@ -676,7 +676,7 @@ mod tests {
     fn add() {
         let first = Vector::new(4.0, 5.0);
         let second = Vector::new(2.0, 3.0);
-        let sum = &first + &second;
+        let sum = first + second;
         assert_eq!(sum.x, 6.0);
         assert_eq!(sum.y, 8.0);
     }
@@ -684,72 +684,72 @@ mod tests {
     fn sub() {
         let first = Vector::new(4.0, 5.0);
         let second = Vector::new(2.0, 3.0);
-        let difference = &first - &second;
+        let difference = first - second;
         assert_eq!(difference.x, 2.0);
         assert_eq!(difference.y, 2.0);
     }
     #[test]
     fn mul() {
         let vector = Vector::new(2.0, 4.0);
-        let multiplied = &vector * 2.5;
+        let multiplied = vector * 2.5;
         assert_eq!(multiplied.x, 5.0);
         assert_eq!(multiplied.y, 10.0);
     }
     #[test]
     fn mul_transitive() {
         let vector = Vector::new(2.0, 4.0);
-        let first_multiplied = &vector * 2.5;
-        let second_multiplied = 2.5 * &vector;
+        let first_multiplied = vector * 2.5;
+        let second_multiplied = 2.5 * vector;
         assert_eq!(first_multiplied.x, second_multiplied.x);
         assert_eq!(first_multiplied.y, second_multiplied.y);
     }
     #[test]
     fn mul_tuple() {
         let vector = Vector::new(4.0, 1.0);
-        let multiplied = &vector * (0.5, 2.0);
+        let multiplied = vector * (0.5, 2.0);
         assert_eq!(multiplied.x, 2.0);
         assert_eq!(multiplied.y, 2.0);
     }
     #[test]
     fn mul_tuple_transitive() {
         let vector = Vector::new(6.0, 3.0);
-        let first_multiplied = &vector * (0.25, -0.5);
-        let second_multiplied = (0.25, -0.5) * &vector;
+        let first_multiplied = vector * (0.25, -0.5);
+        let second_multiplied = (0.25, -0.5) * vector;
         assert_eq!(first_multiplied.x, second_multiplied.x);
         assert_eq!(first_multiplied.y, second_multiplied.y);
     }
     #[test]
     fn div() {
         let vector = Vector::new(4.0, 2.0);
-        let divided = &vector / 2.0;
+        let divided = vector / 2.0;
         assert_eq!(divided.x, 2.0);
         assert_eq!(divided.y, 1.0);
     }
     #[test]
     fn div_tuple() {
         let vector = Vector::new(-8.0, 6.0);
-        let divided = &vector / (4.0, -3.0);
+        let divided = vector / (4.0, -3.0);
         assert_eq!(divided.x, -2.0);
         assert_eq!(divided.y, -2.0);
     }
     #[test]
     fn neg() {
         let vector = Vector::new(1.0, -1.0);
-        let inverse_vector = -&vector;
+        let inverse_vector = -vector;
         assert_eq!(inverse_vector.x, -1.0);
         assert_eq!(inverse_vector.y, 1.0);
     }
     #[test]
     fn add_assign() {
         let mut vector = Vector::new(1.0, -2.0);
-        vector += &Vector::new(-5.0, 3.0);
+        vector += Vector::new(-5.0, 3.0);
         assert_eq!(vector.x, -4.0);
         assert_eq!(vector.y, 1.0);
     }
     #[test]
     fn sub_assign() {
         let mut vector = Vector::new(1.0, -2.0);
-        vector -= &Vector::new(-5.0, 3.0);
+        vector -= Vector::new(-5.0, 3.0);
         assert_eq!(vector.x, 6.0);
         assert_eq!(vector.y, -5.0);
     }

--- a/tests/mosaic_creation.rs
+++ b/tests/mosaic_creation.rs
@@ -120,7 +120,7 @@ mod starry_mosaic_tests {
 
         let mosaic = mosaic.unwrap();
         assert_eq!(mosaic.image_size(), image_size);
-        assert_eq!(mosaic.center(), &center);
+        assert_eq!(mosaic.center(), center);
         assert_eq!(mosaic.rotation_angle(), rotation_angle);
         assert_eq!(mosaic.scale(), scale);
 
@@ -190,7 +190,7 @@ mod polygonal_mosaic_tests {
 
         let mosaic = mosaic.unwrap();
         assert_eq!(mosaic.image_size(), image_size);
-        assert_eq!(mosaic.center(), &center);
+        assert_eq!(mosaic.center(), center);
         assert_eq!(mosaic.rotation_angle(), rotation_angle);
         assert_eq!(mosaic.scale(), scale);
 


### PR DESCRIPTION
This pull request transforms Vector type to copyable by value. This change simplifies usage of operators with vectors (vector math).